### PR TITLE
zktraffic tests work on OS X, add test for sniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [What is ZKTraffic?](#what-is-zktraffic)
 - [Contributing and Testing](#contributing-and-testing)
 - [More tools!](#more-tools)
+- [OS X](#os-x)
 - [Dependencies](#dependencies)
 
 ### tl;dr ###
@@ -259,6 +260,13 @@ QuorumPacket(
 )
 ...
 
+```
+
+### OS X ###
+Although no one has tried running this on OS X in production, it can be used for some parts of development and unit testing. If you are running on OS X, please run the following to install the correct dependencies:
+
+```sh
+$ pip install -r ./osx_requirements.txt
 ```
 
 ### Dependencies ###

--- a/osx_requirements.txt
+++ b/osx_requirements.txt
@@ -1,0 +1,7 @@
+-e git+https://github.com/CoreSecurity/pcapy.git@2984bf5e974ab3a2af58c0501f2d4072db5ac4e4#egg=pcapy-10.8
+dpkt-fix
+mock
+nose
+psutil>=2.1.0
+scapy==2.2.0-dev
+twitter.common.log

--- a/zktraffic/base/process.py
+++ b/zktraffic/base/process.py
@@ -46,7 +46,10 @@ class ProcessOptions(object):
         Get CPU affinity of this process
         :return: a list() of CPU cores this processes is pinned to
         """
-        return self.process.cpu_affinity()
+        try:
+          return self.process.cpu_affinity()
+        except AttributeError:
+          log.warn('cpu affinity is not available on your platform')
 
     def set_niceness(self, nice_level):
         """

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -33,7 +33,7 @@ from scapy.config import conf as scapy_conf
 from twitter.common import log
 
 
-scapy_conf.logLevel = logging.ERROR  # shush scappy
+scapy_conf.logLevel = logging.ERROR  # shush scapy
 
 DEFAULT_PORT = 2181
 

--- a/zktraffic/tests/test_process_options.py
+++ b/zktraffic/tests/test_process_options.py
@@ -17,6 +17,7 @@
 
 import mock
 import os
+import sys
 
 from zktraffic.base.process import ProcessOptions
 
@@ -49,8 +50,9 @@ def test_cpu_affinity():
   def mock_cpu_affinity_handler(self, *args, **kwargs):
       return [0, 1]
 
-  # if running in TravisCI, mock the cpu_affinity() method call
-  if os.environ.get('TRAVIS'):
+  # if running in TravisCI, or on OS X without CPI affinty,
+  # mock the cpu_affinity() method call
+  if os.environ.get('TRAVIS') or sys.platform.startswith('darwin'):
       with mock.patch.object(psutil.Process, 'cpu_affinity', create=True, new=mock_cpu_affinity_handler):
           proc.set_cpu_affinity('0,1')
           assert proc.get_cpu_affinity() == [0, 1]

--- a/zktraffic/tests/test_sniffer.py
+++ b/zktraffic/tests/test_sniffer.py
@@ -1,0 +1,56 @@
+# ==================================================================================================
+# Copyright 2014 Twitter, Inc.
+# --------------------------------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this work except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file, or at:
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==================================================================================================
+
+from unittest import TestCase
+import os
+import signal
+import socket
+import sys
+
+from zktraffic.base.sniffer import Sniffer, SnifferConfig
+
+from scapy.sendrecv import sniff
+import mock
+
+class TestSniffer(TestCase):
+  def setUp(self):
+    self.zkt = Sniffer(SnifferConfig())
+
+  @mock.patch('os.kill', spec=os.kill)
+  @mock.patch('zktraffic.base.sniffer.sniff', spec=sniff)
+  def test_run_socket_error(self, mock_sniff, mock_kill):
+    mock_sniff.side_effect = socket.error
+
+    self.zkt.run()
+
+    mock_sniff.assert_called_once_with(
+        filter=self.zkt.config.filter,
+        store=0,
+        prn=self.zkt.handle_packet,
+        iface=self.zkt.config.iface)
+    mock_kill.assert_called_once_with(os.getpid(), signal.SIGINT)
+
+  @mock.patch('os.kill', spec=os.kill)
+  @mock.patch('zktraffic.base.sniffer.sniff', spec=sniff)
+  def test_run(self, mock_sniff, mock_kill):
+    self.zkt.run()
+
+    mock_sniff.assert_called_once_with(
+        filter=self.zkt.config.filter,
+        store=0,
+        prn=self.zkt.handle_packet,
+        iface=self.zkt.config.iface)
+    mock_kill.assert_called_once_with(os.getpid(), signal.SIGINT)


### PR DESCRIPTION
Unit tests pass on OS X.

Although we're still awaiting a [new release of `pcapy` on PyPI](https://github.com/CoreSecurity/pcapy/issues/2) I'm [hosting a package in the interim](https://github.com/Yasumoto/cheeseshop/tree/gh-pages/CoreSecurity/pcapy/2984bf5e974ab3a2af58c0501f2d4072db5ac4e4).

In addition, this was brought about by adding unit test coverage for the sniffer, which was my goal all along.