### PR TITLE
Add support for excluding/including IPs in zk-dump

### DIFF
--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -54,15 +54,24 @@ class SnifferConfig(object):
     self.track_replies = False
     self.max_queued_requests = 10000
     self.zookeeper_port = DEFAULT_PORT
-    self.update_filter()
+    self.included_ips = []
+    self.excluded_ips = []
     self.excluded_opcodes = set()
     self.is_loopback = False
     self.read_timeout_ms = 0
 
+    self.update_filter()
     self.exclude_pings()
 
   def update_filter(self):
     self.filter = "port %d" % (self.zookeeper_port)
+
+    assert not (self.included_ips and self.excluded_ips)
+
+    if self.excluded_ips:
+      self.filter +=  " and host not " + " and host not ".join(self.excluded_ips)
+    elif self.included_ips:
+      self.filter += " and (host " + " or host ".join(self.included_ips) + ")"
 
   def include_pings(self):
     self.update_exclusion_list(OpCodes.PING, False)


### PR DESCRIPTION
Sometimes you only care about sniffing traffic to a given cluster. This
commit adds an option for that:

$ sudo zk-dump --iface lo --include-host some-cluster.domain.tld

When using the --include-host flag, only requests to and from the A and AAAA
records backing some-cluster.domain.tld will be captured.

Similarly, you could be interested in capturing all ZK traffic on a box
_except_ for what's going to a given cluster:

$ sudo zk-dump --iface lo --exclude-host some-cluster.domain.tld

Both flags can be used multiple times to include or exclude more than one
host. Though you can't mix include and exclude flags.

Signed-off-by: Raul Gutierrez S <rgs@twitter.com>