### PR TITLE
fix(multi): extract path from the first subtxn

### DIFF
--- a/zktraffic/tests/test_packets.py
+++ b/zktraffic/tests/test_packets.py
@@ -93,3 +93,4 @@ def test_multi():
   consume_packets('multi', zkt)
 
   assert stats.global_stats.by_op_counters[OpCodes.MULTI] == 1
+  assert stats.by_path["/foo"].ops_written == 1


### PR DESCRIPTION
This is a hack, not a proper fix. We'd need to
rework how we handle paths (right now only path is
expected to be associated with a request) to actually
be able to expose more paths.

Signed-off-by: Raul Gutierrez S <rgs@twitter.com>