### PR TITLE
Deeper dissection of Quorum packets and Reconfig packets

### DIFF
--- a/osx_requirements.txt
+++ b/osx_requirements.txt
@@ -5,3 +5,4 @@ nose
 psutil>=2.1.0
 scapy==2.2.0-dev
 twitter.common.log
+hexdump

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ twitter.common.decorators
 twitter.common.exceptions
 twitter.common.http
 twitter.common.log
+hexdump

--- a/zktraffic/base/client_message.py
+++ b/zktraffic/base/client_message.py
@@ -346,20 +346,20 @@ class Create2Request(CreateRequest):
 class ReconfigRequest(Request):
   OPCODE = OpCodes.RECONFIG
 
-  def __init__(self, size, xid, client, joiningServers, leavingServers, newMembers):
-    super(ReconfigRequest, self).__init__(size, xid, "", client, False)
+  def __init__(self, size, xid, client, server, joiningServers, leavingServers, newMembers):
+    super(ReconfigRequest, self).__init__(size, xid, "", client, False, server)
     self.joiningServers = joiningServers
     self.leavingServers = leavingServers
     self.newMembers = newMembers
 
   @classmethod
-  def with_params(cls, xid, path, watch, data, offset, size, client):
+  def with_params(cls, xid, path, watch, data, offset, size, client, server):
     joiningServers, offset = read_string(data, offset)
     offset = offset + 4 if joiningServers == "" else offset
     leavingServers, offset = read_string(data, offset)
     offset = offset + 4 if leavingServers == "" else offset
     newMembers, offset = read_string(data, offset)
-    return cls(size, xid, client, joiningServers, leavingServers, newMembers)
+    return cls(size, xid, client, server, joiningServers, leavingServers, newMembers)
 
   def __str__(self):
     return "%s(xid=%d, joiningServers=%s, leavingServers=%s, newMembers=%s)\n" % (

--- a/zktraffic/base/client_message.py
+++ b/zktraffic/base/client_message.py
@@ -343,6 +343,29 @@ class Create2Request(CreateRequest):
   OPCODE = OpCodes.CREATE2
 
 
+class ReconfigRequest(Request):
+  OPCODE = OpCodes.RECONFIG
+
+  def __init__(self, size, xid, client, joiningServers, leavingServers, newMembers):
+    super(ReconfigRequest, self).__init__(size, xid, "", client, False)
+    self.joiningServers = joiningServers
+    self.leavingServers = leavingServers
+    self.newMembers = newMembers
+
+  @classmethod
+  def with_params(cls, xid, path, watch, data, offset, size, client):
+    joiningServers, offset = read_string(data, offset)
+    offset = offset + 4 if joiningServers == "" else offset
+    leavingServers, offset = read_string(data, offset)
+    offset = offset + 4 if leavingServers == "" else offset
+    newMembers, offset = read_string(data, offset)
+    return cls(size, xid, client, joiningServers, leavingServers, newMembers)
+
+  def __str__(self):
+    return "%s(xid=%d, joiningServers=%s, leavingServers=%s, newMembers=%s)\n" % (
+      self.name, self.xid, self.joiningServers, self.leavingServers, self.newMembers)
+
+
 class DeleteRequest(Request):
   OPCODE = OpCodes.DELETE
 

--- a/zktraffic/base/server_message.py
+++ b/zktraffic/base/server_message.py
@@ -278,6 +278,18 @@ class Create2Reply(CreateReply):
   OPCODE = OpCodes.CREATE2
 
 
+class ReconfigReply(Reply):
+  OPCODE = OpCodes.RECONFIG
+
+  @classmethod
+  def with_params(cls, xid, zxid, error, data, offset, client, server):
+    return cls(xid, zxid, error, "", client, server)
+
+  def __str__(self):
+    return "%s(xid=%d, error=%d)\n" % (
+      self.name, self.xid, self.error)
+
+
 class SetWatchesReply(Reply):
   OPCODE = OpCodes.SETWATCHES
 

--- a/zktraffic/base/server_message.py
+++ b/zktraffic/base/server_message.py
@@ -286,8 +286,7 @@ class ReconfigReply(Reply):
     return cls(xid, zxid, error, "", client, server)
 
   def __str__(self):
-    return "%s(xid=%d, error=%d)\n" % (
-      self.name, self.xid, self.error)
+    return "%s(xid=%d, error=%d)\n" % (self.name, self.xid, self.error)
 
 
 class SetWatchesReply(Reply):

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -18,9 +18,11 @@
 from collections import defaultdict
 import logging
 import os
+import hexdump
 import signal
 import socket
 import struct
+import sys
 from threading import Thread
 
 from .client_message import ClientMessage, Request
@@ -57,6 +59,7 @@ class SnifferConfig(object):
     self.excluded_opcodes = set()
     self.is_loopback = False
     self.read_timeout_ms = 0
+    self.print_bad_packet = False
 
     # These are set after initialization, and require `update_filter` to be called
     self.included_ips = []
@@ -188,8 +191,13 @@ class Sniffer(Thread):
       if not self.config.excluded(message.opcode):
         for h in self._handlers_for(message):
           h(message)
-    except (BadPacket, DeserializationError, struct.error):
-      pass
+    except (BadPacket, DeserializationError, struct.error) as ex:
+      if self.config.print_bad_packet:
+        print("got: %s" % str(ex))
+        hexdump.hexdump(packet.load)
+        sys.stdout.flush()
+      else:
+        pass
 
   def _handlers_for(self, message):
     if isinstance(message, Request):

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -172,7 +172,10 @@ class Sniffer(Thread):
   def run(self):
     try:
       log.info("Setting filter: %s", self.config.filter)
-      sniff(filter=self.config.filter, store=0, prn=self.handle_packet, iface=self.config.iface)
+      if self.config.iface == "any":
+        sniff(filter=self.config.filter, store=0, prn=self.handle_packet)
+      else:
+        sniff(filter=self.config.filter, store=0, prn=self.handle_packet, iface=self.config.iface)
     except socket.error as ex:
       log.error("Error: %s, device: %s", ex, self.config.iface)
     finally:

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -59,7 +59,7 @@ class SnifferConfig(object):
     self.excluded_opcodes = set()
     self.is_loopback = False
     self.read_timeout_ms = 0
-    self.print_bad_packet = False
+    self.dump_bad_packet = False
 
     # These are set after initialization, and require `update_filter` to be called
     self.included_ips = []
@@ -192,12 +192,10 @@ class Sniffer(Thread):
         for h in self._handlers_for(message):
           h(message)
     except (BadPacket, DeserializationError, struct.error) as ex:
-      if self.config.print_bad_packet:
+      if self.config.dump_bad_packet:
         print("got: %s" % str(ex))
         hexdump.hexdump(packet.load)
         sys.stdout.flush()
-      else:
-        pass
 
   def _handlers_for(self, message):
     if isinstance(message, Request):

--- a/zktraffic/base/zookeeper.py
+++ b/zktraffic/base/zookeeper.py
@@ -40,6 +40,7 @@ class OpCodes(object):
   CHECK = 13
   MULTI = 14
   CREATE2 = 15
+  RECONFIG = 16
   CLOSE = -11
   SETAUTH = 100
   SETWATCHES = 101
@@ -61,6 +62,7 @@ ZK_REQUEST_TYPES = {
   OpCodes.CHECK: 'CheckRequest',
   OpCodes.MULTI: 'MultiRequest',
   OpCodes.CREATE2: 'CreateRequest',
+  OpCodes.RECONFIG: 'ReconfigRequest',
   OpCodes.CLOSE: 'CloseRequest',
   OpCodes.SETAUTH: 'SetAuthRequest',
   OpCodes.SETWATCHES: 'SetWatchesRequest',
@@ -76,7 +78,8 @@ ZK_WRITE_OPS = (
   OpCodes.DELETE,
   OpCodes.SETDATA,
   OpCodes.MULTI,
-  OpCodes.SETACL)
+  OpCodes.SETACL,
+  OpCodes.RECONFIG)
 
 
 ZK_CAN_SET_WATCH = (
@@ -110,7 +113,8 @@ def has_path(opcode):
     OpCodes.PING,
     OpCodes.SETAUTH,
     OpCodes.MULTI,
-    OpCodes.CLOSE)
+    OpCodes.CLOSE,
+    OpCodes.RECONFIG)
 
 
 def read_path(data, offset):

--- a/zktraffic/cli/fle.py
+++ b/zktraffic/cli/fle.py
@@ -26,11 +26,12 @@ def setup():
   app.add_option('--iface', default='eth0', type=str)
   app.add_option('--port', default=3888, type=int)
   app.add_option('-c', '--colors', default=False, action='store_true')
+  app.add_option('--print-bad-packet', default=False, action='store_true')
 
 
 def main(_, options):
   printer = Printer(options.colors)
-  sniffer = Sniffer(options.iface, options.port, Message, printer.add)
+  sniffer = Sniffer(options.iface, options.port, Message, printer.add, options.print_bad_packet)
 
   try:
     while True:

--- a/zktraffic/cli/fle.py
+++ b/zktraffic/cli/fle.py
@@ -26,12 +26,12 @@ def setup():
   app.add_option('--iface', default='eth0', type=str)
   app.add_option('--port', default=3888, type=int)
   app.add_option('-c', '--colors', default=False, action='store_true')
-  app.add_option('--print-bad-packet', default=False, action='store_true')
+  app.add_option('--dump-bad-packet', default=False, action='store_true')
 
 
 def main(_, options):
   printer = Printer(options.colors)
-  sniffer = Sniffer(options.iface, options.port, Message, printer.add, options.print_bad_packet)
+  sniffer = Sniffer(options.iface, options.port, Message, printer.add, options.dump_bad_packet)
 
   try:
     while True:

--- a/zktraffic/cli/zab.py
+++ b/zktraffic/cli/zab.py
@@ -26,12 +26,12 @@ def setup():
   app.add_option('--iface', default='eth0', type=str)
   app.add_option('--port', default=2889, type=int)
   app.add_option('-c', '--colors', default=False, action='store_true')
-  app.add_option('--print-bad-packet', default=False, action='store_true')
+  app.add_option('--dump-bad-packet', default=False, action='store_true')
 
 
 def main(_, options):
   printer = Printer(options.colors)
-  sniffer = Sniffer(options.iface, options.port, QuorumPacket, printer.add, options.print_bad_packet)
+  sniffer = Sniffer(options.iface, options.port, QuorumPacket, printer.add, options.dump_bad_packet)
 
   try:
     while True:

--- a/zktraffic/cli/zab.py
+++ b/zktraffic/cli/zab.py
@@ -26,11 +26,12 @@ def setup():
   app.add_option('--iface', default='eth0', type=str)
   app.add_option('--port', default=2889, type=int)
   app.add_option('-c', '--colors', default=False, action='store_true')
+  app.add_option('--print-bad-packet', default=False, action='store_true')
 
 
 def main(_, options):
   printer = Printer(options.colors)
-  sniffer = Sniffer(options.iface, options.port, QuorumPacket, printer.add)
+  sniffer = Sniffer(options.iface, options.port, QuorumPacket, printer.add, options.print_bad_packet)
 
   try:
     while True:

--- a/zktraffic/cli/zk.py
+++ b/zktraffic/cli/zk.py
@@ -51,6 +51,7 @@ def setup():
                  help='Host that should be included (you can use this multiple times)')
   app.add_option('-p', '--include-pings', default=False, action='store_true')
   app.add_option('-c', '--colors', default=False, action='store_true')
+  app.add_option('--print-bad-packet', default=False, action='store_true')
 
 
 class Requests(object):
@@ -216,6 +217,8 @@ def main(_, options):
 
   if options.include_pings:
     config.include_pings()
+
+  config.print_bad_packet = options.print_bad_packet
 
   loopback = options.iface in ["lo", "lo0"]
 

--- a/zktraffic/cli/zk.py
+++ b/zktraffic/cli/zk.py
@@ -51,7 +51,7 @@ def setup():
                  help='Host that should be included (you can use this multiple times)')
   app.add_option('-p', '--include-pings', default=False, action='store_true')
   app.add_option('-c', '--colors', default=False, action='store_true')
-  app.add_option('--print-bad-packet', default=False, action='store_true')
+  app.add_option('--dump-bad-packet', default=False, action='store_true')
 
 
 class Requests(object):
@@ -218,7 +218,7 @@ def main(_, options):
   if options.include_pings:
     config.include_pings()
 
-  config.print_bad_packet = options.print_bad_packet
+  config.dump_bad_packet = options.dump_bad_packet
 
   loopback = options.iface in ["lo", "lo0"]
 

--- a/zktraffic/network/sniffer.py
+++ b/zktraffic/network/sniffer.py
@@ -44,7 +44,7 @@ class Sniffer(Thread):
   """
   class RegistrationError(Exception): pass
 
-  def __init__(self, iface, port, msg_cls, handler=None, print_bad_packet=False):
+  def __init__(self, iface, port, msg_cls, handler=None, dump_bad_packet=False):
     super(Sniffer, self).__init__()
     self.setDaemon(True)
 
@@ -53,7 +53,7 @@ class Sniffer(Thread):
     self._port = port
     self._packet_size = MAX_PACKET_SIZE
     self._handlers = []
-    self._print_bad_packet = print_bad_packet
+    self._dump_bad_packet = dump_bad_packet
 
     if handler is not None:
       self.add_handler(handler)
@@ -97,12 +97,10 @@ class Sniffer(Thread):
       for h in self._handlers:
         h(message)
     except (BadPacket, struct.error) as ex:
-      if self._print_bad_packet:
+      if self._dump_bad_packet:
         print("got: %s" % str(ex))
         hexdump.hexdump(packet.load)
         sys.stdout.flush()
-      else:
-        pass
     except Exception as ex:
       print("got: %s" % str(ex))
       hexdump.hexdump(packet.load)

--- a/zktraffic/network/sniffer.py
+++ b/zktraffic/network/sniffer.py
@@ -79,7 +79,10 @@ class Sniffer(Thread):
     pfilter = "port %d" % self._port
     try:
       log.info("Setting filter: %s", pfilter)
-      sniff(filter=pfilter, store=0, prn=self.handle_packet, iface=self._iface)
+      if self._iface == "any":
+        sniff(filter=pfilter, store=0, prn=self.handle_packet)
+      else:
+        sniff(filter=pfilter, store=0, prn=self.handle_packet, iface=self._iface)
     except socket.error as ex:
       log.error("Error: %s, device: %s", ex, self._iface)
     finally:

--- a/zktraffic/zab/quorum_packet.py
+++ b/zktraffic/zab/quorum_packet.py
@@ -18,6 +18,7 @@ from datetime import datetime
 
 from zktraffic.base.network import BadPacket
 from zktraffic.base.util import read_long, read_number
+from zktraffic.base.zookeeper import OpCodes, ZK_REQUEST_TYPES
 
 
 class PacketType(object):
@@ -75,7 +76,25 @@ class PacketType(object):
     return "" if cls.invalid(ptype) else cls.NAMES[ptype]
 
 
-class QuorumPacket(object):
+class QuorumPacketBase(type):
+  TYPES = {}
+  PTYPE = None
+
+  def __new__(cls, clsname, bases, dct):
+    obj = super(QuorumPacketBase, cls).__new__(cls, clsname, bases, dct)
+    if obj.PTYPE in cls.TYPES:
+      raise ValueError("Duplicate ptype name: %s" % obj.PTYPE)
+    else:
+      if obj.PTYPE is not None:
+        cls.TYPES[obj.PTYPE] = obj
+      return obj
+
+  @classmethod
+  def get(cls, key, default=None):
+    return cls.TYPES.get(key, default)
+
+
+class QuorumPacket(QuorumPacketBase('QuorumPacketBase', (object,), {})):
   __slots__ = ("timestamp", "src", "dst", "type", "zxid", "length")
 
   MIN_SIZE = 12
@@ -97,6 +116,10 @@ class QuorumPacket(object):
     return PacketType.to_str(self.type)
 
   @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    return cls(timestamp, src, dst, ptype, zxid, len(data))
+
+  @classmethod
   def from_payload(cls, data, src, dst, timestamp):
     if len(data) < cls.MIN_SIZE:
       raise BadPacket("Too small")
@@ -105,16 +128,245 @@ class QuorumPacket(object):
     if PacketType.invalid(ptype):
       raise BadPacket("Invalid type")
 
-    zxid, _ = read_long(data, offset)
-
-    return cls(timestamp, src, dst, ptype, zxid, len(data))
+    zxid, offset = read_long(data, offset)
+    handler = QuorumPacketBase.get(ptype, cls)
+    return handler.with_params(timestamp, src, dst, ptype, zxid, data, offset)
 
   def __str__(self):
-    return "QuorumPacket(\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s\n)\n" % (
-      " " * 5 + "timestamp", self.timestr,
-      " " * 5 + "src", self.src,
-      " " * 5 + "dst", self.dst,
-      " " * 5 + "type", self.type_literal,
-      " " * 5 + "zxid", self.zxid,
-      " " * 5 + "length", self.length,
-    )
+    def gen():
+      for k in dir(self):
+        v = getattr(self, k)
+        cond = (isinstance(v, int) or isinstance(v, basestring)) and \
+               not k.isupper() and not k.startswith('_') and not '_literal' in k \
+               and not k == 'type'
+        if cond:
+          alt_k = '%s_literal' % k
+          if hasattr(self, alt_k):
+            v = getattr(self, alt_k)
+          yield k, v
+    s = '%s(\n' % self.__class__.__name__
+    for k, v in gen():
+        s += ' %s=%s,\n' % (k, v)
+    s += ')\n'
+    return s
+
+    # return "QuorumPacket(\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s\n)\n" % (
+    #   " " * 5 + "timestamp", self.timestr,
+    #   " " * 5 + "src", self.src,
+    #   " " * 5 + "dst", self.dst,
+    #   " " * 5 + "type", self.type_literal,
+    #   " " * 5 + "zxid", self.zxid,
+    #   " " * 5 + "length", self.length,
+    # )
+
+
+class RequestQP(QuorumPacket):
+  PTYPE = PacketType.REQUEST
+  __slots__ = ("session_id", "cxid", "req_type")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               session_id, cxid, req_type):
+    super(RequestQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.session_id = session_id
+    self.cxid = cxid
+    self.req_type = req_type
+
+  @property
+  def req_type_literal(self):
+    return ZK_REQUEST_TYPES[self.req_type] if self.req_type in ZK_REQUEST_TYPES else str(self.req_type)
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    session_id, offset = read_long(data, offset)
+    cxid, offset = read_number(data, offset)
+    req_type, offset = read_number(data, offset)
+    # TODO: dissect the remaining data
+    # see server_message.py and client_message.py
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               session_id, cxid, req_type)
+
+
+class ProposalQP(QuorumPacket):
+  __slots__ = ("client_id", "cxid", "txn_zxid", "txn_time", "txn_type")
+  PTYPE = PacketType.PROPOSAL
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               client_id, cxid, txn_zxid, txn_time, txn_type):
+    super(ProposalQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.client_id = client_id
+    self.cxid = cxid
+    self.txn_zxid = txn_zxid
+    self.txn_time = txn_time
+    self.txn_type = txn_type
+
+  @property
+  def txn_type_literal(self):
+    return ZK_REQUEST_TYPES[self.txn_type] if self.txn_type in ZK_REQUEST_TYPES else str(self.txn_type)
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    client_id, offset = read_long(data, offset)
+    cxid, offset = read_number(data, offset)
+    txn_zxid, offset = read_long(data, offset)
+    txn_time, offset = read_long(data, offset)
+    txn_type, offset = read_number(data, offset)
+    # TODO: dissect the remaining data
+    # see org.apache.zookeeper.server.util.SerializeUtils.deserializeTxn()
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               client_id, cxid, txn_zxid, txn_time, txn_type)
+
+
+class AckQP(QuorumPacket):
+  PTYPE = PacketType.ACK
+
+
+class CommitQP(QuorumPacket):
+  PTYPE = PacketType.COMMIT
+
+
+class PingQP(QuorumPacket):
+  PTYPE = PacketType.PING
+  # TODO: dissect the data (in almost all cases, data is null)
+
+
+class RevalidateQP(QuorumPacket):
+  PTYPE = PacketType.REVALIDATE
+  __slots__ = ("session_id", "timeout")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               session_id, timeout):
+    super(RevalidateQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.session_id = session_id
+    self.timeout = timeout
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    session_id, offset = read_long(data, offset)
+    timeout, offset = read_number(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               session_id, timeout)
+
+
+class SyncQP(QuorumPacket):
+  PTYPE = PacketType.SYNC
+
+
+class InformQP(ProposalQP):
+  PTYPE = PacketType.INFORM
+
+
+class CommitAndActivateQP(QuorumPacket):
+  PTYPE = PacketType.COMMITANDACTIVATE
+  __slots__ = ("suggested_leader_id")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               suggested_leader_id):
+    super(CommitAndActivateQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.suggested_leader_id = suggested_leader_id
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    suggested_leader_id, offset = read_long(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               suggested_leader_id)
+
+
+class NewLeaderQP(QuorumPacket):
+  PTYPE = PacketType.NEWLEADER
+  # TODO: dissect the data (in almost all cases, data is null)
+
+
+class FollowerInfoQP(QuorumPacket):
+  PTYPE = PacketType.FOLLOWERINFO
+  __slots__ = ("sid", "protocol_version", "config_version")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               sid, protocol_version, config_version):
+    super(FollowerInfoQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.sid = sid
+    self.protocol_version = protocol_version
+    self.config_version = config_version
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    sid, offset = read_long(data, offset)
+    protocol_version, offset = read_number(data, offset)
+    config_version, offset = read_long(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               sid, protocol_version, config_version)
+
+
+class UpToDateQP(QuorumPacket):
+  PTYPE = PacketType.UPTODATE
+
+
+class DiffQP(QuorumPacket):
+  PTYPE = PacketType.DIFF
+
+
+class TruncQP(QuorumPacket):
+  PTYPE = PacketType.TRUNC
+
+
+class ObserverInfoQP(FollowerInfoQP):
+  PTYPE = PacketType.OBSERVERINFO
+
+
+class LeaderInfoQP(QuorumPacket):
+  PTYPE = PacketType.LEADERINFO
+  __slots__ = ("protocol_version")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               protocol_version):
+    super(LeaderInfoQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.protocol_version = protocol_version
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    protocol_version, offset = read_number(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               protocol_version)
+
+
+class AckEpochQP(QuorumPacket):
+  PTYPE = PacketType.ACKEPOCH
+  __slots__ = ("epoch")
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               epoch):
+    super(AckEpochQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.epoch = epoch
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    epoch, offset = read_number(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               epoch)
+
+
+class InformAndActivateQP(ProposalQP):
+  __slots__ = ("client_id", "cxid", "txn_zxid", "txn_time", "txn_type", "suggested_leader_id")
+  PTYPE = PacketType.INFORMANDACTIVATE
+  def __init__(self, timestamp, src, dst, ptype, zxid, length,
+               suggested_leader_id,
+               client_id, cxid, txn_zxid, txn_time, txn_type):
+    super(ProposalQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    self.suggested_leader_id = suggested_leader_id
+    self.client_id = client_id
+    self.cxid = cxid
+    self.txn_zxid = txn_zxid
+    self.txn_time = txn_time
+    self.txn_type = txn_type
+
+  @classmethod
+  def with_params(cls, timestamp, src, dst, ptype, zxid, data, offset):
+    data_len, offset = read_number(data, offset)
+    suggested_leader_id, offset = read_long(data, offset)
+    client_id, offset = read_long(data, offset)
+    cxid, offset = read_number(data, offset)
+    txn_zxid, offset = read_long(data, offset)
+    txn_time, offset = read_long(data, offset)
+    txn_type, offset = read_number(data, offset)
+    return cls(timestamp, src, dst, ptype, zxid, len(data),
+               suggested_leader_id,
+               client_id, cxid, txn_zxid, txn_time, txn_type)

--- a/zktraffic/zab/quorum_packet.py
+++ b/zktraffic/zab/quorum_packet.py
@@ -94,7 +94,7 @@ class QuorumPacketBase(type):
     return cls.TYPES.get(key, default)
 
 
-class QuorumPacket(QuorumPacketBase('QuorumPacketBase', (object,), {})):
+class QuorumPacket(QuorumPacketBase("QuorumPacketBase", (object,), {})):
   __slots__ = ("timestamp", "src", "dst", "type", "zxid", "length")
 
   MIN_SIZE = 12
@@ -137,35 +137,28 @@ class QuorumPacket(QuorumPacketBase('QuorumPacketBase', (object,), {})):
       for k in dir(self):
         v = getattr(self, k)
         cond = (isinstance(v, int) or isinstance(v, basestring)) and \
-               not k.isupper() and not k.startswith('_') and not '_literal' in k \
-               and not k == 'type'
+               not k.isupper() and not k.startswith("_") and not "_literal" in k \
+               and not k == "type"
         if cond:
-          alt_k = '%s_literal' % k
+          alt_k = "%s_literal" % k
           if hasattr(self, alt_k):
             v = getattr(self, alt_k)
           yield k, v
-    s = '%s(\n' % self.__class__.__name__
+          
+    s = "%s(\n" % self.__class__.__name__
     for k, v in gen():
-        s += ' %s=%s,\n' % (k, v)
-    s += ')\n'
+        s += " %s=%s,\n" % (k, v)
+    s += ")\n"
     return s
 
-    # return "QuorumPacket(\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s,\n%s=%s\n)\n" % (
-    #   " " * 5 + "timestamp", self.timestr,
-    #   " " * 5 + "src", self.src,
-    #   " " * 5 + "dst", self.dst,
-    #   " " * 5 + "type", self.type_literal,
-    #   " " * 5 + "zxid", self.zxid,
-    #   " " * 5 + "length", self.length,
-    # )
 
-
-class RequestQP(QuorumPacket):
+class Request(QuorumPacket):
   PTYPE = PacketType.REQUEST
   __slots__ = ("session_id", "cxid", "req_type")
+  
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                session_id, cxid, req_type):
-    super(RequestQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(Request, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.session_id = session_id
     self.cxid = cxid
     self.req_type = req_type
@@ -186,12 +179,13 @@ class RequestQP(QuorumPacket):
                session_id, cxid, req_type)
 
 
-class ProposalQP(QuorumPacket):
-  __slots__ = ("client_id", "cxid", "txn_zxid", "txn_time", "txn_type")
+class Proposal(QuorumPacket):
   PTYPE = PacketType.PROPOSAL
+  __slots__ = ("client_id", "cxid", "txn_zxid", "txn_time", "txn_type")
+
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                client_id, cxid, txn_zxid, txn_time, txn_type):
-    super(ProposalQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(Proposal, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.client_id = client_id
     self.cxid = cxid
     self.txn_zxid = txn_zxid
@@ -216,25 +210,25 @@ class ProposalQP(QuorumPacket):
                client_id, cxid, txn_zxid, txn_time, txn_type)
 
 
-class AckQP(QuorumPacket):
+class Ack(QuorumPacket):
   PTYPE = PacketType.ACK
 
 
-class CommitQP(QuorumPacket):
+class Commit(QuorumPacket):
   PTYPE = PacketType.COMMIT
 
 
-class PingQP(QuorumPacket):
+class Ping(QuorumPacket):
   PTYPE = PacketType.PING
   # TODO: dissect the data (in almost all cases, data is null)
 
 
-class RevalidateQP(QuorumPacket):
+class Revalidate(QuorumPacket):
   PTYPE = PacketType.REVALIDATE
   __slots__ = ("session_id", "timeout")
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                session_id, timeout):
-    super(RevalidateQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(Revalidate, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.session_id = session_id
     self.timeout = timeout
 
@@ -247,20 +241,20 @@ class RevalidateQP(QuorumPacket):
                session_id, timeout)
 
 
-class SyncQP(QuorumPacket):
+class Sync(QuorumPacket):
   PTYPE = PacketType.SYNC
 
 
-class InformQP(ProposalQP):
+class Inform(Proposal):
   PTYPE = PacketType.INFORM
 
 
-class CommitAndActivateQP(QuorumPacket):
+class CommitAndActivate(QuorumPacket):
   PTYPE = PacketType.COMMITANDACTIVATE
   __slots__ = ("suggested_leader_id")
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                suggested_leader_id):
-    super(CommitAndActivateQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(CommitAndActivate, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.suggested_leader_id = suggested_leader_id
 
   @classmethod
@@ -271,17 +265,17 @@ class CommitAndActivateQP(QuorumPacket):
                suggested_leader_id)
 
 
-class NewLeaderQP(QuorumPacket):
+class NewLeader(QuorumPacket):
   PTYPE = PacketType.NEWLEADER
   # TODO: dissect the data (in almost all cases, data is null)
 
 
-class FollowerInfoQP(QuorumPacket):
+class FollowerInfo(QuorumPacket):
   PTYPE = PacketType.FOLLOWERINFO
   __slots__ = ("sid", "protocol_version", "config_version")
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                sid, protocol_version, config_version):
-    super(FollowerInfoQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(FollowerInfo, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.sid = sid
     self.protocol_version = protocol_version
     self.config_version = config_version
@@ -296,28 +290,28 @@ class FollowerInfoQP(QuorumPacket):
                sid, protocol_version, config_version)
 
 
-class UpToDateQP(QuorumPacket):
+class UpToDate(QuorumPacket):
   PTYPE = PacketType.UPTODATE
 
 
-class DiffQP(QuorumPacket):
+class Diff(QuorumPacket):
   PTYPE = PacketType.DIFF
 
 
-class TruncQP(QuorumPacket):
+class Trunc(QuorumPacket):
   PTYPE = PacketType.TRUNC
 
 
-class ObserverInfoQP(FollowerInfoQP):
+class ObserverInfo(FollowerInfo):
   PTYPE = PacketType.OBSERVERINFO
 
 
-class LeaderInfoQP(QuorumPacket):
+class LeaderInfo(QuorumPacket):
   PTYPE = PacketType.LEADERINFO
   __slots__ = ("protocol_version")
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                protocol_version):
-    super(LeaderInfoQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(LeaderInfo, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.protocol_version = protocol_version
 
   @classmethod
@@ -328,12 +322,12 @@ class LeaderInfoQP(QuorumPacket):
                protocol_version)
 
 
-class AckEpochQP(QuorumPacket):
+class AckEpoch(QuorumPacket):
   PTYPE = PacketType.ACKEPOCH
   __slots__ = ("epoch")
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                epoch):
-    super(AckEpochQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(AckEpoch, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.epoch = epoch
 
   @classmethod
@@ -344,13 +338,13 @@ class AckEpochQP(QuorumPacket):
                epoch)
 
 
-class InformAndActivateQP(ProposalQP):
+class InformAndActivate(Proposal):
   __slots__ = ("client_id", "cxid", "txn_zxid", "txn_time", "txn_type", "suggested_leader_id")
   PTYPE = PacketType.INFORMANDACTIVATE
   def __init__(self, timestamp, src, dst, ptype, zxid, length,
                suggested_leader_id,
                client_id, cxid, txn_zxid, txn_time, txn_type):
-    super(ProposalQP, self).__init__(timestamp, src, dst, ptype, zxid, length)
+    super(Proposal, self).__init__(timestamp, src, dst, ptype, zxid, length)
     self.suggested_leader_id = suggested_leader_id
     self.client_id = client_id
     self.cxid = cxid


### PR DESCRIPTION
Hello,

The patch set enables deeper dissection of quorum packets(ProposalQP, CommitQP, and so on).
The patch set also includes dissector for Reconfig request/response and several optional features for debugging.

I made these patches for [earthquake](https://github.com/osrg/earthquake/), our model checker for real implementation of distributed systems(Zookeeper and so on).

Earthquakes permutes function calls, packets, and injected fault events in various orders to find bugs of the distributed system.

Zktraffic is used to make digests of packets so as to reduce the state exploration space.
https://github.com/osrg/earthquake/tree/master/example/zk.ether

