### PR TITLE
fix(zk-dump, fle-dump, zab-dump): handle IOError

### DIFF
--- a/zktraffic/cli/fle.py
+++ b/zktraffic/cli/fle.py
@@ -34,7 +34,7 @@ def main(_, options):
   sniffer = Sniffer(options.iface, options.port, Message, printer.add, options.dump_bad_packet)
 
   try:
-    while True:
+    while printer.isAlive():
       sniffer.join(1)
   except (KeyboardInterrupt, SystemExit):
     pass

--- a/zktraffic/cli/printer.py
+++ b/zktraffic/cli/printer.py
@@ -37,6 +37,8 @@ class Printer(Thread):
         self._print(self._queue.popleft())
       except IndexError:
         time.sleep(0.1)
+      except IOError:  # PIPE broken, most likely
+        break
 
   def _print_default(self, msg):
     sys.stdout.write(str(msg))

--- a/zktraffic/cli/zab.py
+++ b/zktraffic/cli/zab.py
@@ -34,7 +34,7 @@ def main(_, options):
   sniffer = Sniffer(options.iface, options.port, QuorumPacket, printer.add, options.dump_bad_packet)
 
   try:
-    while True:
+    while printer.isAlive():
       sniffer.join(1)
   except (KeyboardInterrupt, SystemExit):
     pass


### PR DESCRIPTION
When using zk-dump | head, IOError (SIGPIPE) isn't
handle so the exception bubbles up. This handles
that.

Signed-off-by: Raul Gutierrez S <rgs@twitter.com>