### PR TITLE
fix(fle): fix fle.Notification.config parsing

### DIFF
--- a/zktraffic/fle/message.py
+++ b/zktraffic/fle/message.py
@@ -70,7 +70,12 @@ class Message(object):
       zxid, offset = read_long(data, offset)
       election_epoch, offset = read_long(data, offset)
       peer_epoch, offset = read_long(data, offset) if len(data) > cls.OLD_LEN else (-1, offset)
-      config = data[cls.WITH_CONFIG_LEN:] if len(data) > cls.WITH_CONFIG_LEN else ""
+      config = ""
+      if len(data) > cls.WITH_CONFIG_LEN:
+        currentversion, offset = read_number(data, offset)
+        if currentversion != Notification.CURRENTVERSION:
+          raise BadPacket("Invalid CURRENTVERSION: %d", currentversion)
+        config, _ = read_string(data, offset)
 
       return Notification(
         timestamp,
@@ -113,6 +118,8 @@ class Initial(Message):
 
 
 class Notification(Message):
+  CURRENTVERSION = 0x2
+
   __slots__ = (
     "timestamp",
     "src",

--- a/zktraffic/tests/test_fle_messages.py
+++ b/zktraffic/tests/test_fle_messages.py
@@ -22,23 +22,23 @@ from zktraffic.fle.message import Message
 
 class MessagesTestCase(unittest.TestCase):
   def test_initial_message(self):
-    payload = '%s%s%s%s' % (
+    payload = ''.join((
       '\xff\xff\xff\xff\xff\xff\x00\x00',  # proto version: -65536L
       '\x00\x00\x00\x00\x00\x00\x00\x06',  # server id
       '\x00\x00\x00\x0e',                  # addr len
       '127.0.0.1:3888',                    # addr
-    )
+    ))
     init = Message.from_payload(payload, '127.0.0.1:3888', '127.0.0.1:9000', 0)
     self.assertEqual(6, init.server_id)
     self.assertEqual('127.0.0.1:3888', init.election_addr)
 
   def test_notification_28(self):
-    payload = '%s%s%s%s' % (
+    payload = ''.join((
       '\x00\x00\x00\x01',                  # state
       '\x00\x00\x00\x00\x00\x00\x00\x03',  # leader
-      '\x00\x00\x00\x00\x00\x00 \x00',     # zxid
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # election epoch
-    )
+      '\x00\x00\x00\x00\x00\x00\x20\x00',     # zxid
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',    # election epoch
+    ))
     notif = Message.from_payload(payload, '127.0.0.1:3888', '127.0.0.1:9000', 0)
     self.assertEqual(1, notif.state)
     self.assertEqual(3, notif.leader)
@@ -48,13 +48,13 @@ class MessagesTestCase(unittest.TestCase):
     self.assertEqual('', notif.config)
 
   def test_notification_36(self):
-    payload = '%s%s%s%s%s' % (
+    payload = ''.join((
       '\x00\x00\x00\x01',                  # state
       '\x00\x00\x00\x00\x00\x00\x00\x03',  # leader
-      '\x00\x00\x00\x00\x00\x00 \x00',     # zxid
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # election epoch
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # peer epoch
-    )
+      '\x00\x00\x00\x00\x00\x00\x20\x00',  # zxid
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',  # election epoch
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',  # peer epoch
+    ))
     notif = Message.from_payload(payload, '127.0.0.1:3888', '127.0.0.1:9000', 0)
     self.assertEqual(1, notif.state)
     self.assertEqual(3, notif.leader)
@@ -89,10 +89,10 @@ class MessagesTestCase(unittest.TestCase):
     self.assertEqual(config, notif.config)
 
   def test_invalid_state(self):
-    payload = '%s%s%s%s' % (
+    payload = ''.join((
       '\x00\x00\x00\x05',                  # bad state
       '\x00\x00\x00\x00\x00\x00\x00\x03',  # leader
-      '\x00\x00\x00\x00\x00\x00 \x00',     # zxid
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # election epoch
-    )
+      '\x00\x00\x00\x00\x00\x00\x20\x00',  # zxid
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',  # election epoch
+    ))
     self.assertRaises(BadPacket, Message.from_payload, payload, '127.0.0.1:388', '127.0.0.1:900', 0)

--- a/zktraffic/tests/test_fle_messages.py
+++ b/zktraffic/tests/test_fle_messages.py
@@ -70,14 +70,16 @@ class MessagesTestCase(unittest.TestCase):
       'server.0=10.0.0.3:2889:3888:participant;0.0.0.0:2181',
       'version=deadbeef'
     )
-    payload = '%s%s%s%s%s%s' % (
+    payload = ''.join((
       '\x00\x00\x00\x01',                  # state
       '\x00\x00\x00\x00\x00\x00\x00\x03',  # leader
-      '\x00\x00\x00\x00\x00\x00 \x00',     # zxid
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # election epoch
-      '\x00\x00\x00\x00\x00\x00\x00\n',    # peer epoch
+      '\x00\x00\x00\x00\x00\x00\x20\x00',  # zxid
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',  # election epoch
+      '\x00\x00\x00\x00\x00\x00\x00\x0a',  # peer epoch
+      '\x00\x00\x00\x02',                  # current version
+      '\x00\x00\x00\xaf',                  # config length
       config,
-    )
+    ))
     notif = Message.from_payload(payload, '127.0.0.1:3888', '127.0.0.1:9000', 0)
     self.assertEqual(1, notif.state)
     self.assertEqual(3, notif.leader)

--- a/zktraffic/tests/test_zab.py
+++ b/zktraffic/tests/test_zab.py
@@ -54,11 +54,11 @@ def run_sniffer(handler, pcapfile, port=LEADER_PORT):
 
 class ZabTestCase(unittest.TestCase):
   def test_basic(self):
-    payload = '%s%s%s' % (
+    payload = ''.join((
       '\x00\x00\x00\x02',                  # type
       '\x00\x00\x00\x00\x00\x00\x07\xd0',  # zxid
       'cchenwashere',                      # data
-    )
+    ))
     packet = QuorumPacket.from_payload(payload, '127.0.0.1:2889', '127.0.0.1:10000', 0)
     self.assertEqual(PacketType.PROPOSAL, packet.type)
     self.assertEqual(packet.zxid, 2000)


### PR DESCRIPTION
 [These fields](https://github.com/apache/zookeeper/blob/32fc1417dc649f8a3bb32a224eb6cca3181eb39f/src/java/main/org/apache/zookeeper/server/quorum/FastLeaderElection.java#L591-592)(`FastLeaderElection.buildMsg()`) were unexpectedly prepended to config string.
