### PR TITLE
fix(stats-daemon): call set_cpu_affinity() before spawning threads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ ChangeLog
 Bug Handling
 ************
 - add ansicolors to requirements
+- --set-cpu-affinity wasn't effective on all threads,
+  because set_cpu_affinity() was called after spawning
+  daemon threads
 
 Features
 ********

--- a/zktraffic/cli/stats_daemon.py
+++ b/zktraffic/cli/stats_daemon.py
@@ -101,6 +101,15 @@ def main(_, opts):
     sys.stdout.write("%s\n" % __version__)
     sys.exit(0)
 
+  # set proc options before we spawn threads
+  process = ProcessOptions()
+
+  if opts.niceness >= 0:
+    process.set_niceness(opts.niceness)
+
+  if opts.cpu_affinity:
+    process.set_cpu_affinity(opts.cpu_affinity)
+
   stats = StatsServer(opts.iface,
                       opts.zookeeper_port,
                       opts.aggregation_depth,
@@ -112,14 +121,6 @@ def main(_, opts):
   log.info("Starting with opts: %s" % (opts))
 
   signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-  process = ProcessOptions()
-
-  if opts.niceness >= 0:
-    process.set_niceness(opts.niceness)
-
-  if opts.cpu_affinity:
-    process.set_cpu_affinity(opts.cpu_affinity)
 
   server = Server()
   server.mount_routes(DiagnosticsEndpoints())


### PR DESCRIPTION
I tested this using this flag in prod:

```
/usr/local/bin/zk-stats-daemon \
      --iface=eth0 \
      --aggregation-depth=3 \
      --set-cpu-affinity=7 \   # this would be mask 0x80
      --http-port=9090 \
      --http-address=127.0.0.1
```

And all threads have the right cpu affinity mask now:

```
$ taskset -p 9572
pid 9572's current affinity mask: 80
$ taskset -p 9571
pid 9571's current affinity mask: 80
$ taskset -p 9567
pid 9567's current affinity mask: 80
```
