### PR TITLE
Perf improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ChangeLog
 =========
 
-0.1.7 (2015-07-XX)
+0.1.7 (2015-12-XX)
 --------------------
 
 Bug Handling
@@ -15,6 +15,8 @@ Features
 ********
 - zk-omni-dump: zk + fle + zab sniffer with automatic port detection. This
   is useful for JUnit testcases where ports are randomly assigned
+- zk-stats-daemon now supports --sampling to capture only a % of packets,
+  which is useful to reduce the amount of consumed CPU time
 
 0.1.6 (2015-07-10)
 --------------------

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -16,6 +16,7 @@
 
 
 from collections import defaultdict
+from random import random
 from threading import Thread
 
 import logging
@@ -69,6 +70,7 @@ class SnifferConfig(object):
     self.is_loopback = False
     self.read_timeout_ms = 0
     self.dump_bad_packet = False
+    self.sampling = 1.0  # percentage of packets to inspect [0, 1]
 
     # These are set after initialization, and require `update_filter` to be called
     self.included_ips = []
@@ -211,6 +213,10 @@ class Sniffer(SnifferBase):
       os.kill(os.getpid(), signal.SIGINT)
 
   def handle_packet(self, packet):
+    sampling = self.config.sampling
+    if sampling < 1.0 and random() > sampling:
+      return
+
     try:
       message = self.message_from_packet(packet)
       self.handle_message(message)

--- a/zktraffic/base/sniffer.py
+++ b/zktraffic/base/sniffer.py
@@ -248,22 +248,24 @@ class Sniffer(SnifferBase):
     client_port = self.config.client_port
     zk_port = self.config.zookeeper_port
     ip_p = get_ip_packet(packet.load, client_port, zk_port, self.config.is_loopback)
-    data = ip_p.data.data
-    src = intern("%s:%s" % (get_ip(ip_p, ip_p.src), ip_p.data.sport))
-    dst = intern("%s:%s" % (get_ip(ip_p, ip_p.dst), ip_p.data.dport))
-    timestamp = packet.time
 
     if ip_p.data.dport == zk_port:
+      data = ip_p.data.data
+      src = intern("%s:%s" % (get_ip(ip_p, ip_p.src), ip_p.data.sport))
+      dst = intern("%s:%s" % (get_ip(ip_p, ip_p.dst), ip_p.data.dport))
       client, server = src, dst
       if data.startswith(FOUR_LETTER_WORDS):
         self._set_four_letter_mode(client, data[0:4])
         raise BadPacket("Four letter request %s" % data[0:4])
       client_message = ClientMessage.from_payload(data, client, server)
-      client_message.timestamp = timestamp
+      client_message.timestamp = packet.time
       self._track_client_message(client_message)
       return client_message
 
     if ip_p.data.sport == zk_port:
+      data = ip_p.data.data
+      src = intern("%s:%s" % (get_ip(ip_p, ip_p.src), ip_p.data.sport))
+      dst = intern("%s:%s" % (get_ip(ip_p, ip_p.dst), ip_p.data.dport))
       client, server = dst, src
       four_letter = self._get_four_letter_mode(client)
       if four_letter:
@@ -271,7 +273,7 @@ class Sniffer(SnifferBase):
         raise BadPacket("Four letter response %s" % four_letter)
       requests_xids = self._requests_xids.get(client, {})
       server_message = ServerMessage.from_payload(data, client, server, requests_xids)
-      server_message.timestamp = timestamp
+      server_message.timestamp = packet.time
       return server_message
 
     raise BadPacket("Packet to the wrong port?")

--- a/zktraffic/cli/stats_daemon.py
+++ b/zktraffic/cli/stats_daemon.py
@@ -127,8 +127,7 @@ def main(_, opts):
   server.mount_routes(stats)
   server.run(opts.http_addr, opts.http_port)
 
-  while True:
-    time.sleep(10)
+  stats.sniffer.join()
 
 
 if __name__ == '__main__':

--- a/zktraffic/cli/stats_daemon.py
+++ b/zktraffic/cli/stats_daemon.py
@@ -76,6 +76,10 @@ def setup():
                  type=str,
                  default=None,
                  help="A comma-separated list of CPU cores to pin this process to")
+  app.add_option("--sampling",
+                 type=float,
+                 default=1.0,
+                 help="Percentage of packets to inspect [0, 1]")
   app.add_option("--max-queued-requests",
                  type=int,
                  default=400000,
@@ -110,13 +114,18 @@ def main(_, opts):
   if opts.cpu_affinity:
     process.set_cpu_affinity(opts.cpu_affinity)
 
+  if opts.sampling < 0 or opts.sampling > 1:
+    sys.stdout.write("--sampling takes values within [0, 1]\n")
+    sys.exit(1)
+
   stats = StatsServer(opts.iface,
                       opts.zookeeper_port,
                       opts.aggregation_depth,
                       opts.max_results,
                       opts.max_queued_requests,
                       opts.max_queued_replies,
-                      opts.max_queued_events)
+                      opts.max_queued_events,
+                      sampling=opts.sampling)
 
   log.info("Starting with opts: %s" % (opts))
 

--- a/zktraffic/endpoints/endpoints_server.py
+++ b/zktraffic/endpoints/endpoints_server.py
@@ -24,10 +24,12 @@ class EndpointsServer(HttpServer):
   MAX_RESULTS = 10
 
   def __init__(
-      self, iface, zkport, request_handler, reply_handler=None, event_handler=None, start_sniffer=True):
+      self, iface, zkport, request_handler,
+      reply_handler=None, event_handler=None, start_sniffer=True, sampling=1.0):
     config = SnifferConfig(iface=iface)
     config.zookeeper_port = zkport
     config.update_filter()
+    config.sampling = sampling
 
     self._sniffer = Sniffer(config, request_handler, reply_handler, event_handler)
 

--- a/zktraffic/endpoints/stats_server.py
+++ b/zktraffic/endpoints/stats_server.py
@@ -40,7 +40,8 @@ class StatsServer(EndpointsServer):
                max_reps=400000,
                max_events=400000,
                start_sniffer=True,
-               timer=None):
+               timer=None,
+               sampling=1.0):
 
     # Forcing a load of the multiprocessing module here
     # seem to be hitting http://bugs.python.org/issue8200
@@ -62,7 +63,8 @@ class StatsServer(EndpointsServer):
       self._stats.handle_request,
       self._stats.handle_reply,
       self._stats.handle_event,
-      start_sniffer)
+      start_sniffer,
+      sampling=sampling)
 
   def wakeup(self):
     self._stats.wakeup()


### PR DESCRIPTION
Even though --set-cpu-affinity is great to pin zk-stats-daemon to just one CPU, it still uses too much of it when there is a high packet rate.

This PR introduces a few optimizations to reduce memory usage plus --sampling to avoid inspecting _all_ packets (which can help a lot on busy servers). 